### PR TITLE
Add endpoints to get a single and all available organisations

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -479,6 +479,26 @@ paths:
         '404':
           description: User not found
 
+  /organizations:
+    get:
+      summary: 'Get all organizations'
+      tags:
+        - 'Organizations'
+      responses:
+        '200':
+          description: Return the list of all organizations
+
+  /organizations/{organizationId}:
+    get:
+      summary: 'Get a single organization'
+      tags:
+        - 'Organizations'
+      responses:
+        '200':
+          description: Return the organization
+        '404':
+          description: Organization does not exist
+
 
   /user:
     get:

--- a/src/__tests__/routes/organization.test.js
+++ b/src/__tests__/routes/organization.test.js
@@ -47,17 +47,17 @@ describe('Organization auth', () => {
         .post(`${urlPrefix}/auth/login`)
         .send({ username, password });
       expect(resp.status).toBe(403);
-      expect(resp.body.message).toBe('Check your email for account verification',);
+      expect(resp.body.message).toBe('Check your email for account verification');
     });
 
     test('should verify the account', async () => {
-      const resp = await request(app).get(`${urlPrefix}/auth/verification/${tokenLog}`,);
+      const resp = await request(app).get(`${urlPrefix}/auth/verification/${tokenLog}`);
       expect(resp.status).toBe(200);
-      expect(resp.body.message).toBe('Your account has been verified successfully',);
+      expect(resp.body.message).toBe('Your account has been verified successfully');
     });
 
     test('should not verify the account when it is already verified', async () => {
-      const resp = await request(app).get(`${urlPrefix}/auth/verification/${tokenLog}`,);
+      const resp = await request(app).get(`${urlPrefix}/auth/verification/${tokenLog}`);
       expect(resp.status).toBe(400);
       expect(resp.body.message).toBe('Your account has already been verified');
     });
@@ -66,9 +66,9 @@ describe('Organization auth', () => {
       const expiredToken = jwt.sign({ id: userId }, process.env.SECRET, {
         expiresIn: '0.1s',
       });
-      const resp = await request(app).get(`${urlPrefix}/auth/verification/${expiredToken}`,);
+      const resp = await request(app).get(`${urlPrefix}/auth/verification/${expiredToken}`);
       expect(resp.status).toBe(401);
-      expect(resp.body.message).toBe('Your verification email has expired, try to login to receive a new one',);
+      expect(resp.body.message).toBe('Your verification email has expired, try to login to receive a new one');
     });
   });
 
@@ -86,9 +86,39 @@ describe('Organization auth', () => {
         .post(`${urlPrefix}/auth/login`)
         .send({ username: 'company', password: 'CompanyN1233' });
       expect(resp.status).toBe(401);
-      expect(resp.body.message).toBe('The credentials you provided are incorrect',);
+      expect(resp.body.message).toBe('The credentials you provided are incorrect');
     });
   });
+
+  describe('organizations model', () => {
+    it('gets all available organizations', async () => {
+      const resp = await request(app)
+        .get(`${urlPrefix}/organizations`);
+      expect(resp.status).toBe(200);
+      expect(resp.body.organizations[0].name).toBe('company name');
+    });
+
+    it('gets a single organization', async () => {
+      const resp = await request(app)
+        .get(`${urlPrefix}/organizations/${userId}`);
+      expect(resp.status).toBe(200);
+      expect(resp.body.organization.name).toBe('company name');
+    });
+
+    it('Returns a message when an organization is not found', async () => {
+      const resp = await request(app)
+        .get(`${urlPrefix}/organizations/9cef8a70a12d893fd282dfb8`);
+      expect(resp.status).toBe(404);
+      expect(resp.body.message).toBe('Organization does not exist');
+    });
+
+    it('Returns a message when an organization Id format is invalid', async () => {
+      const resp = await request(app)
+        .get(`${urlPrefix}/organizations/wrongFormatOrganizationID`);
+      expect(resp.status).toBe(400);
+      expect(resp.body.message).toBe('Wrong Id format');
+    });
+  })
 
   afterAll(async () => {
     await User.deleteOne({ email: organization.email });

--- a/src/controllers/OrganizationController.js
+++ b/src/controllers/OrganizationController.js
@@ -1,0 +1,47 @@
+import { Organization } from '../models';
+import { statusCodes, responseMessages } from '../constants';
+
+/**
+ * @description Organization Controller class
+ */
+export default class OrganizationsController {
+
+	/**
+	 * Get all organizations
+	 *
+	 * @static
+	 * @param {*} req
+	 * @param {*} res
+	 * @returns {void} organizations
+	 * @memberof OrganizationsController
+	 */
+    static async getAll(req, res) {
+        const organizations = await Organization.find({})
+            .populate('user')
+            .exec();
+
+        return res.status(statusCodes.OK).json({
+            status: statusCodes.OK,
+            organizations
+        });
+    }
+
+    /**
+	 * Get a single organization
+	 *
+	 * @static
+	 * @param {*} req
+	 * @param {*} res
+	 * @returns {void} organization
+	 * @memberof OrganizationsController
+	 */
+    static async get(req, res) {
+        const { organization } = req;
+
+        return res.status(statusCodes.OK).json({
+            status: statusCodes.OK,
+            organization
+        });
+    }
+
+}

--- a/src/middlewares/checkOrganization.js
+++ b/src/middlewares/checkOrganization.js
@@ -1,0 +1,37 @@
+import { Organization } from '../models';
+import * as statusCodes from '../constants/statusCodes';
+import { notExist } from '../constants/responseMessages';
+
+const checkOrganization = async (req, res, next) => {
+  const { organizationId: _id } = req.params;
+
+  if (!/[0-9A-F]{24}$/i.test(_id)) {
+    return res.status(statusCodes.BAD_REQUEST).json({
+      status: statusCodes.BAD_REQUEST,
+      message: 'Wrong Id format',
+    });
+  }
+
+  const organization = await Organization.findOne({
+    _id,
+    status: { $ne: 'deleted' },
+  })
+    .select('-__v')
+    .populate(
+      'user',
+      'picture followerCount followedCount createdAt recommendations username email',
+    );
+
+  if (!organization) {
+    return res.status(statusCodes.NOT_FOUND).json({
+      status: statusCodes.NOT_FOUND,
+      message: notExist('Organization'),
+    });
+  }
+
+  req.organization = organization;
+
+  next();
+};
+
+export default checkOrganization;

--- a/src/middlewares/checkProfile.js
+++ b/src/middlewares/checkProfile.js
@@ -9,7 +9,7 @@ const checkProfile = async (req, res, next) => {
     username,
     status: { $ne: 'deleted' },
   })
-    .select('username email picture city country info')
+    .select(['-status', '-createdAt', '-updatedAt', '-password'])
     .populate('info', '-__v');
 
   if (!foundProfile) {

--- a/src/routes/api/v1/index.js
+++ b/src/routes/api/v1/index.js
@@ -9,6 +9,7 @@ import educations from './educations';
 import experiences from './experiences';
 import projects from './projects';
 import follow from './follow';
+import organizations from './organizations';
 
 const router = express.Router();
 
@@ -22,5 +23,6 @@ router.use('/educations', educations);
 router.use('/experiences', experiences);
 router.use('/projects', projects);
 router.use('/follow', follow);
+router.use('/organizations', organizations);
 
 export default router;

--- a/src/routes/api/v1/organizations.js
+++ b/src/routes/api/v1/organizations.js
@@ -1,0 +1,16 @@
+import express from 'express';
+import { OrganizationController } from '../../../controllers';
+import {
+    asyncHandler,
+    checkOrganization
+} from '../../../middlewares';
+
+const router = express.Router();
+
+router
+    .route('/').get(asyncHandler(OrganizationController.getAll));
+
+router
+    .route('/:organizationId').get(checkOrganization, asyncHandler(OrganizationController.get));
+
+export default router;


### PR DESCRIPTION
#### What does this PR do?
This PR adds two endpoints to get a single and all organizations

#### Description of Task to be completed?
- Create the routes
- Create the controllers to get a single and all organizations
- Write tests
- Write the doc

#### How should this be manually tested?
-Fetch the branch and checkout to it.
- Start the server
-Go to the browser and type `localhost:500/api/v1/organizations` to get all
-Go to the browser and type `localhost:500/api/v1/organizations/{organizationId}` to get a single organization

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A