### PR TITLE
fix: add liked to the single post respone

### DIFF
--- a/src/__tests__/routes/posts.test.js
+++ b/src/__tests__/routes/posts.test.js
@@ -140,10 +140,15 @@ describe('posts', () => {
   describe('retreive a post', () => {
     beforeAll(async () => {
       const res = await request(app)
-        .post(`${urlPrefix}/posts`)
+        .post(`${urlPrefix}/posts`) 
         .set('Authorization', token)
         .send(postData);
+
       postSlug = res.body.post.slug;
+      
+      await request(app)
+        .post(`${urlPrefix}/posts/${postSlug}/like`)
+        .set('Authorization', token)
     });
 
     test('should return `Post does not exist`', async () => {
@@ -156,6 +161,14 @@ describe('posts', () => {
       const res = await request(app).get(`${urlPrefix}/posts/${postSlug}`);
       expect(res.status).toBe(statusCodes.OK);
       expect(res.body.post).toHaveProperty('title');
+    });
+
+    test('should  return `a post` with liked to true', async () => {
+      const res = await request(app)
+        .get(`${urlPrefix}/posts/${postSlug}`)
+        .set('Authorization', token);
+      expect(res.status).toBe(statusCodes.OK);
+      expect(res.body.post).toHaveProperty('liked');
     });
   });
 

--- a/src/controllers/PostController.js
+++ b/src/controllers/PostController.js
@@ -1,4 +1,4 @@
-import { Post, Share } from '../models';
+import { Post, Share, Like } from '../models';
 import { statusCodes, responseMessages } from '../constants';
 import { notifEvents } from '../middlewares/registerEvents';
 /**
@@ -118,11 +118,11 @@ export default class PostController {
    * @returns {Object} Returns the response
    */
   static async getPost(req, res) {
-    const { post } = req;
-
+    const { post, currentUser } = req;
+    const likedPost = await PostController.checkLikes(currentUser, post)
     return res.status(statusCodes.OK).json({
       status: statusCodes.OK,
-      post,
+      post: likedPost,
     });
   }
 
@@ -173,5 +173,25 @@ export default class PostController {
       message: responseMessages.updated('Post'),
       share,
     });
+  }
+
+   /**
+   * Checks the user
+   *
+   * @static
+   * @author Karl Musingo
+   * @param {*} currentUser
+   * @param {*} post
+   * @returns {object} feed
+   */
+  static async checkLikes(currentUser, post) {
+    if (currentUser) {
+      const likes = await Like.find({ user: currentUser._id, post:  post._id })
+        .lean()
+        .exec();
+      if (likes) return { ...post.toObject(), liked: true };
+      return post;
+    }
+    return post;
   }
 }

--- a/src/routes/api/v1/posts.js
+++ b/src/routes/api/v1/posts.js
@@ -12,6 +12,7 @@ import {
   checkPost,
   checkPostComment,
   checkPostAndJob,
+  optionalCheckAuth
 } from '../../../middlewares';
 
 const router = express.Router();
@@ -28,7 +29,7 @@ router
 router
   .route('/:postSlug')
   .all(checkPost)
-  .get(asyncHandler(PostController.getPost))
+  .get(optionalCheckAuth, asyncHandler(PostController.getPost))
   .put(
     checkAuth,
     celebrate({ body: postValidator.updatePost }),


### PR DESCRIPTION
#### What does this PR do?
Add liked to the single post response
#### Description of Task to be completed?
When the user is logged in and they fetch a single post, the response should contain whether or not they have liked the post
#### How should this be manually tested?

#### Screenshots (if appropriate)

#### Questions:
